### PR TITLE
Fix barcode for TCPDF 6.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 - fixed filtering of locations by type
 - adapted to work with PHP 5.6
+- fixed the barcode show when using TCPDF library version 6.7.4 or newer
 
 ## [1.0.17] - Improvements
 - added error message when receiving a "401 Unauthorized" error

--- a/overrides/tcpdf/tcpdf_config.php
+++ b/overrides/tcpdf/tcpdf_config.php
@@ -4,3 +4,4 @@ define('K_TCPDF_EXTERNAL_CONFIG', true);
 
 /* Allow generate barcode image */
 define('K_TCPDF_CALLS_IN_HTML', true);
+define('K_ALLOWED_TCPDF_TAGS', '|write1DBarcode|');

--- a/src/Shipment/Manifest.php
+++ b/src/Shipment/Manifest.php
@@ -133,8 +133,12 @@ class Manifest
         foreach ($this->orders as $order) {
             $count++;
             $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '">' . $order->getTracking() . '</td>';
-            if ($this->show_barcode) {
-                $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '" style="line-height: 50%;"><tcpdf data="' . $pdf->serializeTCPDFtag('write1DBarcode', $this->getBarcodeParams($order->getTracking())) . '" /></td>';
+            if ($this->show_barcode && defined('K_TCPDF_CALLS_IN_HTML') && K_TCPDF_CALLS_IN_HTML === true) {
+                if (method_exists($pdf, 'serializeTCPDFtagParameters')) {
+                    $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '" style="line-height: 50%;"><tcpdf method="write1DBarcode" params="' . $pdf->serializeTCPDFtagParameters($this->getBarcodeParams($order->getTracking())) . '" /></td>';
+                } elseif (method_exists($pdf, 'serializeTCPDFtag')) {
+                    $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '" style="line-height: 50%;"><tcpdf data="' . $pdf->serializeTCPDFtag('write1DBarcode', $this->getBarcodeParams($order->getTracking())) . '" /></td>';
+                }
             }
             $order_table .= '<tr>
                 <td width = "' . $this->column_lengths['row_number'] . '" align="right">' . $count . '.</td>

--- a/src/Shipment/Manifest.php
+++ b/src/Shipment/Manifest.php
@@ -134,7 +134,7 @@ class Manifest
             $count++;
             $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '">' . $order->getTracking() . '</td>';
             if ($this->show_barcode) {
-                $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '" style="line-height: 50%;"><tcpdf method="write1DBarcode" params="' . $pdf->serializeTCPDFtagParameters($this->getBarcodeParams($order->getTracking())) . '" /></td>';
+                $cell_shipment_number = '<td width="' . $this->column_lengths['shipment_number'] . '" style="line-height: 50%;"><tcpdf data="' . $pdf->serializeTCPDFtag('write1DBarcode', $this->getBarcodeParams($order->getTracking())) . '" /></td>';
             }
             $order_table .= '<tr>
                 <td width = "' . $this->column_lengths['row_number'] . '" align="right">' . $count . '.</td>


### PR DESCRIPTION
Problema kyla dėl TCPDF bibliotekos versijoje 6.7.5 pasikeitusios funkcijos aprašytos TCPDF bibliotekos example_049.
Pakeitimai matomi čia:
https://github.com/mijora/omniva-woocommerce/commit/236af698619e31e914643bdb886e466dadda7c60#diff-56a304e2454259ee2bbcb5b1feca33db7a910123140c9e04c482cbe5a275b6c3

Pabandžius Omniva bibliotekoje atlikti nurodytus pakeitimus, dėl kažkokios priežasties iš vis nerodo barkodo, todėl reikia surasti kodėl arba downgradint TCPDF biblioteką į versiją 6.6.5