### PR TITLE
Adds X-Integration-Agent-Id header to api calls #86c1rz2pm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Integration header]
+- added `X-Integration-Agent-Id` header to all API calls with value of constant `_OMNIVA_INTEGRATION_AGENT_ID_` if it is defined
+
 ## [1.3.1]
 - added phone number conversion to international format for Lithuania
 

--- a/READMEOMX.md
+++ b/READMEOMX.md
@@ -6,3 +6,6 @@ except for below mentioned changes. Library will try to convert old parameters t
 - All packages **require** ID. Based on on this ID (usually it will be order ID from client system) library decides if this is a multilabel or consolidated registration.
 - Giving same ID to multiple packages marks as consolidation where first added package will be used as main one and the rest as consolidated. **NOTE!** Consolidated packages can only have FRAGILE as additional service.
 - Calling courier returns call ID, which can be used to cancel given call (if cancelation is no longer possible API returns error).
+- To identify developer global constant `_OMNIVA_INTEGRATION_AGENT_ID_` is checked if defined:
+    - `_OMNIVA_INTEGRATION_AGENT_ID_` format is `XXXXXX_YYYYYY` where XXXXXX is ID given by Omniva and YYYYYY is your implementation version, eg. `0123456_Opencart_v3.3`. Any space (" ") will be replaces by underscore ("_").
+    - if constant is defined it will be attached to API calls header `X-Integration-Agent-Id`.

--- a/src/Request.php
+++ b/src/Request.php
@@ -413,6 +413,10 @@ class Request
             "Pragma: no-cache",
         );
 
+        if (defined('_OMNIVA_INTEGRATION_AGENT_ID_')) {
+            $headers[] = "X-Integration-Agent-Id: Developer_" . str_replace(' ', '_', _OMNIVA_INTEGRATION_AGENT_ID_);
+        }
+
         if ($request->getRequestMethod() === OmxRequestInterface::REQUEST_METHOD_POST) {
             $headers[] = "Content-length: " . mb_strlen($body);
         }


### PR DESCRIPTION
- To identify developer global constant `_OMNIVA_INTEGRATION_AGENT_ID_` is checked if defined:
    - `_OMNIVA_INTEGRATION_AGENT_ID_` format is `XXXXXX_YYYYYY` where XXXXXX is ID given by Omniva and YYYYYY is your implementation version, eg. `0123456_Opencart_v3.3`. Any space (" ") will be replaces by underscore ("_").
    - if constant is defined it will be attached to API calls header `X-Integration-Agent-Id`.