### PR TITLE
Fix tracking events parsing

### DIFF
--- a/src/Shipment/Tracking.php
+++ b/src/Shipment/Tracking.php
@@ -40,8 +40,8 @@ class Tracking
             }
             $all_trackings = $this->request->getTracking();
 
-            if (isset($all_trackings->event)) {
-                foreach ($all_trackings->event as $event) {
+            if (isset($all_trackings['tracking']->event)) {
+                foreach ($all_trackings['tracking']->event as $event) {
                     if (in_array((string) $event->packetCode, $barcodes)) {
                         if (!isset($trackings[(string)$event->packetCode] )) {
                             $trackings[(string) $event->packetCode] = array();


### PR DESCRIPTION
Properly handle the tracking response from Request::getTracking()

\Mijora\Omniva\Request::getTracking returns `array{tracking: \SimpleXMLElement, debug: array}`. Therefore, we need to get events from the `tracking` element and treat `$all_trackings` as an array, not as an object.